### PR TITLE
06 14 bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,10 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      npm:
+        patterns: ["*"]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Auto-merge Dependabot PRs
-        uses: gesslar/dependabot-auto-comment-merge@main
+        uses: gesslar/dependabot-auto-merge@main
         with:
           # GitHub token with permissions to merge PRs
           # For organization-wide access, use a personal access token
@@ -30,14 +30,14 @@ jobs:
           # Comma-separated list of repositories to check for Dependabot PRs
           # If not set, all repositories of the owner will be processed
           # Example: "repo1,repo2,repo3"
-          repositories: ${{ vars.DEPENDABOT_AUTO_COMMENT_REPOS }}
+          repositories: ${{ vars.DEPENDABOT_AUTO_MERGE_REPOS }}
 
           # Comma-separated list of repositories to ignore
           # Useful when processing all repos but wanting to exclude specific ones
           # Example: "ignore-repo1,ignore-repo2"
-          ignore-repositories: ${{ vars.DEPENDABOT_AUTO_COMMENT_IGNORE_REPOS }}
+          ignore-repositories: ${{ vars.DEPENDABOT_AUTO_MERGE_IGNORE_REPOS }}
 
-          # Dry run mode - if true, will only log actions without posting comments
+          # Dry run mode - if true, will only log actions without enabling auto-merge
           # Default: false
           dry-run: ${{ vars.DEPENDABOT_DRY_RUN }}
 
@@ -54,12 +54,12 @@ jobs:
 | `repo-owner` | Repository owner (can be a username or organization name). Used to determine which repositories to scan for Dependabot PRs. | No | `${{ github.repository_owner }}` |
 | `repositories` | Comma-separated list of repositories to check for Dependabot PRs. If not provided, all repositories of the owner will be checked. | No | All repos of owner |
 | `ignore-repositories` | Comma-separated list of repositories to ignore. Useful when checking all repos but wanting to exclude a few. | No | None |
-| `dry-run` | If set to "true", the action will log what it would do without actually merging. Useful for testing. | No | `false` |
+| `dry-run` | If set to "true", the action will log what it would do without enabling auto-merge. Useful for testing. | No | `false` |
 | `merge-type` | Specifies the merge strategy to use when enabling auto-merge for Dependabot PRs. Valid values are: `merge`, `rebase`, or `squash`. | No | `merge` |
 
 ## License
 
-`dependabot-auto-comment-merge` is released under the [0BSD](LICENSE.txt).
+`dependabot-auto-merge` is released under the [0BSD](LICENSE.txt).
 
 This package includes or depends on third-party components under their own
 licenses:

--- a/dist/index.js
+++ b/dist/index.js
@@ -36282,7 +36282,7 @@ const mergeFlags = {
       const dependabotPRs = prs.filter(pr => pr.user.login === "dependabot[bot]")
       info(`Found ${dependabotPRs.length} open Dependabot PRs in ${repoOwner}/${repo}`)
 
-      // Comment on each PR
+      // Enable auto-merge on each PR
       for(const pr of dependabotPRs) {
         info(`→ PR #${pr.number}: ${pr.title}`)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dependabot-auto-comment-merge",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dependabot-auto-comment-merge",
-      "version": "1.6.1",
+      "version": "1.7.0",
       "license": "0BSD",
       "dependencies": {
         "@actions/core": "^3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "dependabot-auto-comment-merge",
+  "name": "dependabot-auto-merge",
   "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "dependabot-auto-comment-merge",
+      "name": "dependabot-auto-merge",
       "version": "1.7.0",
       "license": "0BSD",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dependabot-auto-comment-merge",
+  "name": "dependabot-auto-merge",
   "version": "1.7.0",
   "description": "GitHub Action to automatically enable auto-merge on open Dependabot PRs",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependabot-auto-comment-merge",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "GitHub Action to automatically enable auto-merge on open Dependabot PRs",
   "main": "index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -79,7 +79,7 @@ const mergeFlags = {
       const dependabotPRs = prs.filter(pr => pr.user.login === "dependabot[bot]")
       core.info(`Found ${dependabotPRs.length} open Dependabot PRs in ${repoOwner}/${repo}`)
 
-      // Comment on each PR
+      // Enable auto-merge on each PR
       for(const pr of dependabotPRs) {
         core.info(`→ PR #${pr.number}: ${pr.title}`)
 


### PR DESCRIPTION
- **1.7.0**
- **yeah yeah yeah**

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR renames the package from `dependabot-auto-comment-merge` to `dependabot-auto-merge`, bumps the version to 1.7.0, and adds an npm package ecosystem entry to `dependabot.yml`.

- Renames the package name across `package.json`, `package-lock.json`, `README.md`, and updates all corresponding variable references (`DEPENDABOT_AUTO_COMMENT_REPOS` → `DEPENDABOT_AUTO_MERGE_REPOS`, etc.).
- Adds an npm dependency grouping rule to `.github/dependabot.yml` that bundles all npm packages into a single daily update PR.
- Updates a stale comment in both `src/index.js` and `dist/index.js` to reflect the actual behavior (enabling auto-merge rather than commenting).

<h3>Confidence Score: 5/5</h3>

The changes are a straightforward rename and version bump with no logic modifications — safe to merge.

All functional code is unchanged; only the package name, version strings, README variable names, and one stale inline comment were updated. The new dependabot npm grouping rule is additive and follows the existing pattern.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["aroomahoo"](https://github.com/gesslar/dependabot-auto-merge/commit/34df13c811e886e39b858f8e56e18acd668c7892) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37508622)</sub>

<!-- /greptile_comment -->